### PR TITLE
enable ppc64le

### DIFF
--- a/.ci_support/linux_ppc64le_r_base4.3.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.3.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.3'
+target_platform:
+- linux-ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ matrix:
       arch: ppc64le
       dist: focal
 
+    - env: CONFIG=linux_ppc64le_r_base4.3 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
 script:
   - export CI=travis
   - export GIT_BRANCH="$TRAVIS_BRANCH"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_r_base4.3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1364&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-mixtools-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_r_base4.3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_r_base4.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1364&branchName=main">

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  {% if r_base == "4.3" %}
-  skip: True              # [ppc64le]
-  {% endif %}
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -72,25 +69,9 @@ about:
     Science (Grant No. 2020-255193).'
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: mixtools
-# Version: 2.0.0
-# Date: 2022-12-04
-# Title: Tools for Analyzing Finite Mixture Models
-# Authors@R: c(person("Derek", "Young", role = c("aut", "cre"), email = "derek.young@uky.edu", comment = c(ORCID = "0000-0002-3048-3803")), person("Tatiana", "Benaglia", role = "aut"), person("Didier", "Chauveau", role = "aut"), person("David", "Hunter", role = "aut"), person("Kedai", "Cheng", role = "aut"), person("Ryan", "Elmore", role = "ctb"), person("Thomas", "Hettmansperger", role = "ctb"), person("Hoben", "Thomas", role = "ctb"), person("Fengjuan", "Xuan", role = "ctb"))
-# Depends: R (>= 4.0.0)
-# Imports: kernlab, MASS, plotly, scales, segmented, stats, survival
-# URL: https://github.com/dsy109/mixtools
-# Description: Analyzes finite mixture models for various parametric and semiparametric settings.  This includes mixtures of parametric distributions (normal, multivariate normal, multinomial, gamma), various Reliability Mixture Models (RMMs), mixtures-of-regressions settings (linear regression, logistic regression, Poisson regression, linear regression with changepoints, predictor-dependent mixing proportions, random effects regressions, hierarchical mixtures-of-experts), and tools for selecting the number of components (bootstrapping the likelihood ratio test statistic, mixturegrams, and model selection criteria).  Bayesian estimation of mixtures-of-linear-regressions models is available as well as a novel data depth method for obtaining credible bands.  This package is based upon work supported by the National Science Foundation under Grant No. SES-0518772 and the Chan Zuckerberg Initiative: Essential Open Source Software for Science (Grant No. 2020-255193).
-# License: GPL (>= 2)
-# NeedsCompilation: yes
-# Packaged: 2022-12-05 06:17:17 UTC; derekyoung
-# Author: Derek Young [aut, cre] (<https://orcid.org/0000-0002-3048-3803>), Tatiana Benaglia [aut], Didier Chauveau [aut], David Hunter [aut], Kedai Cheng [aut], Ryan Elmore [ctb], Thomas Hettmansperger [ctb], Hoben Thomas [ctb], Fengjuan Xuan [ctb]
-# Maintainer: Derek Young <derek.young@uky.edu>
-# Repository: CRAN
-# Date/Publication: 2022-12-05 14:30:02 UTC


### PR DESCRIPTION
After https://github.com/conda-forge/r-htmlwidgets-feedstock/issues/20 we should be able to support **linux-ppc64le** on R 4.3.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
